### PR TITLE
Refactor DBConn to DBConfig Struct

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -35,6 +35,8 @@ func successResponse(arg interface{}) *fiber.Map {
 func GetTickerDataHandler(svc Service) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 
+		// TODO: put the API params in a struct or something for validation?
+
 		type resp struct {
 			Ticker string               `json:"ticker"`
 			Data   []fetchers.PriceData `json:"data"`

--- a/api/service.go
+++ b/api/service.go
@@ -31,7 +31,7 @@ func NewService(db db.Database, dbConn *sql.DB, fetcher fetchers.DataFetcher) Se
 
 func (s *service) GetTickerData(ctx context.Context, ticker string, startDate, endDate time.Time, interval string) ([]fetchers.PriceData, error) {
 
-	tickerExists, err := s.db.CheckTickerExists(ticker, s.dbConn)
+	tickerExists, err := s.db.CheckTickerExists(ticker)
 	if err != nil {
 		return nil, err
 	}

--- a/api/service.go
+++ b/api/service.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"log"
 	"time"
@@ -17,14 +16,12 @@ type Service interface {
 
 type service struct {
 	db      db.Database
-	dbConn  *sql.DB
 	fetcher fetchers.DataFetcher
 }
 
-func NewService(db db.Database, dbConn *sql.DB, fetcher fetchers.DataFetcher) Service {
+func NewService(db db.Database, fetcher fetchers.DataFetcher) Service {
 	return &service{
 		db:      db,
-		dbConn:  dbConn,
 		fetcher: fetcher,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -18,10 +18,11 @@ import (
 func main() {
 
 	dbCfg := db.NewPostgresConfig()
-	db := db.NewPostgresDatabase(dbCfg)
+	dbConn := dbCfg.Connect()
+
+	db := db.NewPostgresDatabase(dbConn)
 	log.Println("Established PostgresDatabase struct.")
 
-	dbConn := db.Connect()
 	log.Println("Successfully connected to DB.")
 	defer dbConn.Close()
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	fetcher := fetchers.NewYahooFinanceFetcher()
 
-	svc := server.NewService(db, dbConn, fetcher)
+	svc := server.NewService(db, fetcher)
 
 	app := fiber.New()
 

--- a/objects/db/db.go
+++ b/objects/db/db.go
@@ -1,87 +1,13 @@
 package db
 
 import (
-	"database/sql"
-	"fmt"
 	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/ryanlattanzi/go-hello-world/objects/fetchers"
-	"github.com/ryanlattanzi/go-hello-world/utils"
 )
 
 type Database interface {
 	CheckTickerExists(ticker string) (bool, error)
 	GetDataBetweenDates(t string, startDate, endDate time.Time) ([]fetchers.PriceData, error)
-}
-
-func NewPostgresDatabase(conn *sql.DB) *PostgresDatabase {
-	return &PostgresDatabase{
-		dbConn: conn,
-	}
-}
-
-type PostgresDatabase struct {
-	dbConn *sql.DB
-}
-
-func (p *PostgresDatabase) CheckTickerExists(t string) (bool, error) {
-
-	rows, err := p.dbConn.Query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'public';")
-
-	if err != nil {
-		return false, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var existingTicker string
-		err := rows.Scan(&existingTicker)
-		if err != nil {
-			return false, err
-		}
-		if existingTicker == t {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
-
-func (p *PostgresDatabase) GetDataBetweenDates(t string, startDate, endDate time.Time) ([]fetchers.PriceData, error) {
-
-	query := fmt.Sprintf(
-		"SELECT * FROM %s WHERE %s BETWEEN %s AND %s;",
-		t,
-		fetchers.DateCol,
-		startDate.Format(utils.DateOnly),
-		endDate.Format(utils.DateOnly),
-	)
-
-	rows, err := p.dbConn.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var priceData []fetchers.PriceData
-
-	for rows.Next() {
-		var pd fetchers.PriceData
-		err := rows.Scan(
-			&pd.Date,
-			&pd.Open,
-			&pd.High,
-			&pd.Low,
-			&pd.Close,
-			&pd.AdjClose,
-			&pd.Volume,
-		)
-		if err != nil {
-			return nil, err
-		}
-		priceData = append(priceData, pd)
-	}
-
-	return priceData, nil
 }

--- a/objects/db/dbconfig.go
+++ b/objects/db/dbconfig.go
@@ -1,12 +1,13 @@
 package db
 
 import (
+	"database/sql"
 	"fmt"
 	"os"
 )
 
 type DatabaseConfig interface {
-	GetConnectionStr() string
+	Connect() *sql.DB
 }
 
 func NewPostgresConfig() PostgresDatabaseConfig {
@@ -25,6 +26,21 @@ type PostgresDatabaseConfig struct {
 	user     string
 	password string
 	dbname   string
+}
+
+func (pgcfg PostgresDatabaseConfig) Connect() *sql.DB {
+	connStr := pgcfg.GetConnectionStr()
+	db, err := sql.Open("postgres", connStr)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if err = db.Ping(); err != nil {
+		panic(err)
+	}
+
+	return db
 }
 
 func (pgcfg PostgresDatabaseConfig) GetConnectionStr() string {

--- a/objects/db/dbconfig.go
+++ b/objects/db/dbconfig.go
@@ -2,51 +2,8 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
-	"os"
 )
 
 type DatabaseConfig interface {
 	Connect() *sql.DB
-}
-
-func NewPostgresConfig() PostgresDatabaseConfig {
-	return PostgresDatabaseConfig{
-		host:     os.Getenv("POSTGRES_HOST"),
-		port:     os.Getenv("POSTGRES_PORT"),
-		user:     os.Getenv("POSTGRES_USER"),
-		password: os.Getenv("POSTGRES_PASSWORD"),
-		dbname:   os.Getenv("POSTGRES_DB"),
-	}
-}
-
-type PostgresDatabaseConfig struct {
-	host     string
-	port     string
-	user     string
-	password string
-	dbname   string
-}
-
-func (pgcfg PostgresDatabaseConfig) Connect() *sql.DB {
-	connStr := pgcfg.GetConnectionStr()
-	db, err := sql.Open("postgres", connStr)
-
-	if err != nil {
-		panic(err)
-	}
-
-	if err = db.Ping(); err != nil {
-		panic(err)
-	}
-
-	return db
-}
-
-func (pgcfg PostgresDatabaseConfig) GetConnectionStr() string {
-	connStr := fmt.Sprintf("host=%s port=%s user=%s "+
-		"password=%s dbname=%s sslmode=disable",
-		pgcfg.host, pgcfg.port, pgcfg.user, pgcfg.password, pgcfg.dbname,
-	)
-	return connStr
 }

--- a/objects/db/postgresdb.go
+++ b/objects/db/postgresdb.go
@@ -1,0 +1,81 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/ryanlattanzi/go-hello-world/objects/fetchers"
+	"github.com/ryanlattanzi/go-hello-world/utils"
+)
+
+func NewPostgresDatabase(conn *sql.DB) *PostgresDatabase {
+	return &PostgresDatabase{
+		dbConn: conn,
+	}
+}
+
+type PostgresDatabase struct {
+	dbConn *sql.DB
+}
+
+func (p *PostgresDatabase) CheckTickerExists(t string) (bool, error) {
+
+	rows, err := p.dbConn.Query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'public';")
+
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var existingTicker string
+		err := rows.Scan(&existingTicker)
+		if err != nil {
+			return false, err
+		}
+		if existingTicker == t {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (p *PostgresDatabase) GetDataBetweenDates(t string, startDate, endDate time.Time) ([]fetchers.PriceData, error) {
+
+	query := fmt.Sprintf(
+		"SELECT * FROM %s WHERE %s BETWEEN %s AND %s;",
+		t,
+		fetchers.DateCol,
+		startDate.Format(utils.DateOnly),
+		endDate.Format(utils.DateOnly),
+	)
+
+	rows, err := p.dbConn.Query(query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var priceData []fetchers.PriceData
+
+	for rows.Next() {
+		var pd fetchers.PriceData
+		err := rows.Scan(
+			&pd.Date,
+			&pd.Open,
+			&pd.High,
+			&pd.Low,
+			&pd.Close,
+			&pd.AdjClose,
+			&pd.Volume,
+		)
+		if err != nil {
+			return nil, err
+		}
+		priceData = append(priceData, pd)
+	}
+
+	return priceData, nil
+}

--- a/objects/db/postgresdbconfig.go
+++ b/objects/db/postgresdbconfig.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+)
+
+func NewPostgresConfig() PostgresDatabaseConfig {
+	return PostgresDatabaseConfig{
+		host:     os.Getenv("POSTGRES_HOST"),
+		port:     os.Getenv("POSTGRES_PORT"),
+		user:     os.Getenv("POSTGRES_USER"),
+		password: os.Getenv("POSTGRES_PASSWORD"),
+		dbname:   os.Getenv("POSTGRES_DB"),
+	}
+}
+
+type PostgresDatabaseConfig struct {
+	host     string
+	port     string
+	user     string
+	password string
+	dbname   string
+}
+
+func (pgcfg PostgresDatabaseConfig) Connect() *sql.DB {
+	connStr := pgcfg.GetConnectionStr()
+	db, err := sql.Open("postgres", connStr)
+
+	if err != nil {
+		panic(err)
+	}
+
+	if err = db.Ping(); err != nil {
+		panic(err)
+	}
+
+	return db
+}
+
+func (pgcfg PostgresDatabaseConfig) GetConnectionStr() string {
+	connStr := fmt.Sprintf("host=%s port=%s user=%s "+
+		"password=%s dbname=%s sslmode=disable",
+		pgcfg.host, pgcfg.port, pgcfg.user, pgcfg.password, pgcfg.dbname,
+	)
+	return connStr
+}


### PR DESCRIPTION
to make things cleaner, moved the `Connect()` method from the `Database` interface to the `DatabaseConfig` interface. that way, the `Database` takes in a db connection from the `DatabaseConfig`, and can reference that conn when making calls to the db instead of needing it to be passed in as an arg.

also reformatted a little bit and threw the `postgres` implementations in their own files.