### PR TITLE
Adding GetTickerData Handler Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ server:
 
 kill:
 	docker compose down
+
+test:
+	go test ./... -cover

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ ___
 
 There are three query params expected:
 - `ticker` (required)
-- `start_date` (optional; defaults to 1900-01-01)
+- `start_date` (optional; defaults to "1900-01-01")
     - Expected format: YYYY-MM-DD
 - `end_date` (optional; defaults to today's date)
     - Expected format: YYYY-MM-DD
+    - Note that the data returned is up to (but not including) the `end_date` requested. e.g. sending a request with `end_date=2023-03-15` will return data for `2023-03-14`, but not for `2023-03-15`.
+- `interval` (optional; defaults to "1d")
+    - Currently, "1d" is the only valid input until we beef out the fetcher(s).
 
 ---
 
@@ -24,13 +27,15 @@ There are two `make` commands:
     - Optional argument `detach` defaults to `false` so you can see the logs.
 - `make kill`
     - Kills the containers with a simple `docker compose down`.
+- `make test`
+    - Runs all unit tests.
 
 Once the environment is healthy and the server is up, you can run `curl` commands to see the magic work, such as:
 
 ```
 curl 'http://localhost:8080/api/v1/prices?ticker=AAPL&start_date=2023-03-01'
 curl 'http://localhost:8080/api/v1/prices?ticker=MSFT&start_date=2022-01-01&end_date=2023-03-04'
-curl 'http://localhost:8080/api/v1/prices?ticker=TSLA'
+curl 'http://localhost:8080/api/v1/prices?ticker=TSLA&interval=1d'
 ```
 
 ---
@@ -39,7 +44,6 @@ curl 'http://localhost:8080/api/v1/prices?ticker=TSLA'
 
 This is a young buck that is still a work in progress to beef up. Tasks on the horizon are:
 
-- Adding test coverage.
 - Adding CI/CD GH Action workflows.
 - Adding terraform (or AWS CDK?) IaC. Ideally, we'd have this running as an ECS service in a private subnet, with the access path being API Gateway, Network Load Balancer, and finally Application Load Balancer.
 - See what other endpoints and functionalities make sense for this service.

--- a/api/tests/app.go
+++ b/api/tests/app.go
@@ -1,0 +1,24 @@
+package api_tests
+
+import (
+	"github.com/MCTS/get-dat-money/api"
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	apiGroupName     = "/api"
+	versionGroupName = "/v1"
+
+	getTickerData = "/prices"
+)
+
+func setupTestApp(svc api.Service) *fiber.App {
+	app := fiber.New()
+	apiGroup := app.Group(apiGroupName)
+	versionGroup := apiGroup.Group(versionGroupName)
+
+	// Every new endpoint and associated handler needs to be added here.
+	versionGroup.Get(getTickerData, api.GetTickerDataHandler(svc))
+
+	return app
+}

--- a/api/tests/handlers_test.go
+++ b/api/tests/handlers_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/MCTS/get-dat-money/objects/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -57,5 +59,22 @@ func TestGetTickerDataHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
-	t.Run("Success_OnlyStartDate", func(t *testing.T) {})
+	t.Run("Success_OnlyStartDate", func(t *testing.T) {
+
+		svc.On(
+			"GetTickerData",
+			mock.AnythingOfType("*fasthttp.RequestCtx"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("string"),
+		).Return([]db.PriceData{}, nil)
+
+		target := fmt.Sprint(getTickerDataEndpoint, "?ticker=AAPL")
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
 }

--- a/api/tests/handlers_test.go
+++ b/api/tests/handlers_test.go
@@ -1,0 +1,61 @@
+package api_tests
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	getTickerDataEndpoint = fmt.Sprint(apiGroupName, versionGroupName, getTickerData)
+)
+
+func TestGetTickerDataHandler(t *testing.T) {
+	var (
+		svc = &serviceMock{}
+		app = setupTestApp(svc)
+	)
+
+	t.Run("Fail_MissingTicker", func(t *testing.T) {
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, getTickerDataEndpoint, nil))
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Fail_WrongStartDateFmt", func(t *testing.T) {
+
+		target := fmt.Sprint(getTickerDataEndpoint, "?ticker=AAPL&start_date=20210101")
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Fail_WrongEndDateFmt", func(t *testing.T) {
+
+		target := fmt.Sprint(getTickerDataEndpoint, "?ticker=AAPL&end_date=01/01/2021")
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Fail_InvalidInterval", func(t *testing.T) {
+
+		target := fmt.Sprint(getTickerDataEndpoint, "?ticker=AAPL&interval=oneday")
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, target, nil))
+
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("Success_OnlyStartDate", func(t *testing.T) {})
+}

--- a/api/tests/mocks.go
+++ b/api/tests/mocks.go
@@ -1,0 +1,19 @@
+package api_tests
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/MCTS/get-dat-money/objects/db"
+)
+
+type serviceMock struct {
+	mock.Mock
+}
+
+func (sm *serviceMock) GetTickerData(ctx context.Context, ticker, startDate, endDate, interval string) ([]db.PriceData, error) {
+	args := sm.Called(ctx, ticker, startDate, endDate, interval)
+
+	return args.Get(0).([]db.PriceData), args.Error(1)
+}

--- a/api/validators.go
+++ b/api/validators.go
@@ -9,26 +9,14 @@ import (
 func validateDateOnlyFmt(timeStr string) error {
 	_, err := utils.ParseTimeStringDateOnly(timeStr)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid date: `%s`. ensure fmt YYYY-MM-DD", timeStr)
 	}
 	return nil
 }
 
 func validateInterval(interval string) error {
 	valid := []string{
-		"1m",
-		"2m",
-		"5m",
-		"15m",
-		"30m",
-		"60m",
-		"90m",
-		"1h",
 		"1d",
-		"5d",
-		"1wk",
-		"1mo",
-		"3mo",
 	}
 
 	c := utils.SliceContains(valid, interval)

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/andybalholm/brotli v1.0.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofiber/fiber/v2 v2.42.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -17,9 +18,12 @@ require (
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94 // indirect
 	github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/tinylib/msgp v1.1.6 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.44.0 // indirect
@@ -27,6 +31,7 @@ require (
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.4.8 // indirect
 	gorm.io/gorm v1.24.6 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gofiber/fiber/v2 v2.42.0 h1:Fnp7ybWvS+sjNQsFvkhf4G8OhXswvB6Vee8hM/LyS+8=
 github.com/gofiber/fiber/v2 v2.42.0/go.mod h1:3+SGNjqMh5VQH5Vz2Wdi43zTIV16ktlFd3x3R6O1Zlc=
@@ -39,6 +40,7 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
 github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -49,12 +51,15 @@ github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d h1:Q+gqLBOPkFGHyCJx
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
@@ -121,6 +126,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gorm.io/driver/postgres v1.4.8 h1:NDWizaclb7Q2aupT0jkwK8jx1HVCNzt+PQ8v/VnxviA=
 gorm.io/driver/postgres v1.4.8/go.mod h1:O9MruWGNLUBUWVYfWuBClpf3HeGjOoybY0SNmCs3wsw=


### PR DESCRIPTION
adding test coverage for the handler `GetTickerData()`. This basically verifies that our query parameter validators work as expected - there are numerous tests meant to fail when given invalid params. Involved creating an extremely simple service mock and a simple test app. added `make test` command to execute these tests.

Smaller updates:
- changed the only valid `interval` param to be `1d` since the others weren't working with yahoo finance.
- updated README

**NOTE**: Whenever a new endpoint is added to this api, we need to add the endpoint to `api/tests/app.go` to test it. See the comment in that file for where to place it.

Next steps:
- create gh actions ci workflow to run tests on all `push`
- update the api response fields to work better with client code in [carl-von-clausewitz](https://github.com/Margin-Call-Trading-Services/carl-von-clausewitz)