### PR TITLE
Adding CI Testing Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI (Unit testing)
+on: [push]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.19', '1.20' ]
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install dependencies
+        run: go get .
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test with the Go CLI
+        run: go test ./... -cover


### PR DESCRIPTION
Adding unit testing GH Action workflow. Runs on every `push`, and checks on both Go version 1.19 and 1.20.

Successful runs:

![Screen Shot 2023-03-16 at 2 24 50 PM](https://user-images.githubusercontent.com/45903952/225717481-18ba0b41-979a-4011-bfbb-519ce7eb3c11.png)

Showing successful test (same output as local):

![Screen Shot 2023-03-16 at 2 26 46 PM](https://user-images.githubusercontent.com/45903952/225717991-f5b6feb0-dc4e-4ecc-a436-329b9e8f3dee.png)

Configured repo to require these to pass before merging into `main`:

![Screen Shot 2023-03-16 at 2 25 30 PM](https://user-images.githubusercontent.com/45903952/225717634-0f911aff-edce-4d4d-9ccb-388c15d18842.png)


